### PR TITLE
Update GameObject.scala

### DIFF
--- a/src/physics/objects/GameObject.scala
+++ b/src/physics/objects/GameObject.scala
@@ -51,7 +51,7 @@ class GameObject(var location: PhysicsVector, var dimensions: PhysicsVector) {
     * @param face Indicates with which face of the object collided
     */
   def collideWithDynamicObject(otherObject: DynamicObject, face: Integer): Unit = {
-    this.collideWithDynamicObjectCalled = false
+    this.collideWithDynamicObjectCalled = true
     this.otherObject = otherObject
     this.face = face
   }


### PR DESCRIPTION
collideWithDynamicObjectCalled should be set to true when collideWithDynamicObject is called for propper debugging. In GameObject's current implementation collideWithDynamicObjectCalled will never be true.